### PR TITLE
Locked Dependency Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
 		"react-dom": "^18"
 	},
 	"devDependencies": {
-		"@types/node": "^20",
-		"@types/react": "^18",
-		"@types/react-dom": "^18",
-		"eslint": "^8",
+		"@types/node": "22.5.4",
+		"@types/react": "18.3.5",
+		"@types/react-dom": "18.3.0",
+		"eslint": "9.10.0",
 		"eslint-config-next": "14.2.8",
-		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-sonarjs": "^2.0.2",
-		"husky": "^9.1.5",
-		"lint-staged": "^15.2.10",
+		"eslint-config-prettier": "9.1.0",
+		"eslint-plugin-sonarjs": "2.0.2",
+		"husky": "9.1.5",
+		"lint-staged": "15.2.10",
 		"prettier": "3.3.3",
-		"typescript": "^5"
+		"typescript": "5.5.4"
 	}
 }


### PR DESCRIPTION
Locked all dependency versions to be explicitly the current latest versions.
This will prevent future potential incompatibilities.